### PR TITLE
Added shadow on desktop sub-menu

### DIFF
--- a/config/rapidez/menu.php
+++ b/config/rapidez/menu.php
@@ -8,7 +8,7 @@ return [
             'category' => 'block p-3 text-neutral font-bold',
         ],
         2 => [
-            'ul'       => 'hidden absolute flex bg-white border p-3 z-10 sm:group-hover:flex',
+            'ul'       => 'hidden shadow absolute flex bg-white border p-3 z-10 sm:group-hover:flex',
             'li'       => 'px-3',
             'category' => 'block text-neutral font-bold py-3',
         ],


### PR DESCRIPTION
Checked this with @jordythevulder and we added a shadow like the minicart or account dropdown.

See: https://github.com/rapidez/core/pull/723