### PR TITLE
Change shadow class from 'shadow' to 'shadow-sm' for tailwind 4 support

### DIFF
--- a/config/rapidez/menu.php
+++ b/config/rapidez/menu.php
@@ -8,7 +8,7 @@ return [
             'category' => 'block px-3 py-3.5 font-semibold',
         ],
         2 => [
-            'ul'       => 'hidden shadow absolute flex bg-white border p-3 z-10 sm:group-hover:flex',
+            'ul'       => 'hidden shadow-sm absolute flex bg-white border p-3 z-10 sm:group-hover:flex',
             'li'       => 'px-3',
             'category' => 'block font-semibold py-3',
         ],


### PR DESCRIPTION
In Tailwind 4 shadow is changed to `shadow-sm` 